### PR TITLE
0.8_2020-09-27: add "Water tap"

### DIFF
--- a/Presets_OneClickNL-preset.xml
+++ b/Presets_OneClickNL-preset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0"
   author="smootheFiets, Dirk Stöcker"
-  version="0.7_2020-09-11"
+  version="0.8_2020-09-27"
   icon="https://upload.wikimedia.org/wikipedia/commons/2/20/Flag_of_the_Netherlands.svg"
   shortdescription="One click settings NL"
   de.shortdescription="Ein-Klick-Einstellungen NL"
@@ -219,6 +219,12 @@
       <key key="barrier" value="bollard" />
     </item>
     
+    <!-- Misc -->
+    <item name="Water tap" type="node">
+      <key key="man_made" value="water_tap" />
+      <key key="drinking_water" value="yes" />
+      <key key="amenity" value="drinking_water" />
+    </item>
       
   </group>
 </presets>

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Link to the forked preset: https://josm.openstreetmap.de/wiki/Presets/OneClick (
 * 0.5_2020-08-27: add one-click cattle-grid and bollard (without attributes)
 * 0.6_2020-09-03: adapt side-path G13: delete bicycle tag (was: bicycle=yes), set cycleway=separate
 * 0.7_2020-09-11: add one-click traffic_calming=chicane/island
+* 0.8_2020-09-27: add "Water tap"


### PR DESCRIPTION
Not a road feature per se, but enormously handy to know for, e.g., bicycle touring.  I keep forgetting the recommended combination of tags, so here it is!